### PR TITLE
Update gposingway-update.bat

### DIFF
--- a/gposingway-update.bat
+++ b/gposingway-update.bat
@@ -1,4 +1,5 @@
 @echo off
+cd /d "%~dp0"
 cls
 setlocal enabledelayedexpansion
 setlocal ENABLEEXTENSIONS


### PR DESCRIPTION
Make script run in the right folder when run as admin resolving a win11 permission issue a friend had.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of the update script by ensuring it always runs from its own directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->